### PR TITLE
Fix .gitignore for backup/enc files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,6 +82,8 @@ ssl
 nbproject
 public/uploads/*
 !public/uploads/.gitkeep
+public/uploads_backup*/
+*.tar.gz.enc
 
 ############################
 # Node.js


### PR DESCRIPTION
## Summary
- ignore `public/uploads_backup` assets
- ignore encrypted `tar.gz` backup archives

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684140a776e48320a78131766816ba69